### PR TITLE
feat: 居住エリアに最近の入力履歴ボタンを追加 (#45)

### DIFF
--- a/ui/staff/views/session.py
+++ b/ui/staff/views/session.py
@@ -207,17 +207,22 @@ class CustomerFieldUpdateView(LoginRequiredMixin, StaffRequiredMixin, StoreMixin
         actual_value = getattr(customer, field_name)
         is_filled = actual_value is not None and actual_value != ""
 
-        response = render(
-            request,
-            "ui/staff/_zone_task.html",
-            {
-                "task": task,
-                "config": config,
-                "customer": customer,
-                "filled": is_filled,
-                "filled_label": self._filled_label(field_name, actual_value) if is_filled else "",
-            },
-        )
+        ctx = {
+            "task": task,
+            "config": config,
+            "customer": customer,
+            "filled": is_filled,
+            "filled_label": self._filled_label(field_name, actual_value) if is_filled else "",
+        }
+        if field_name == "area" and not is_filled:
+            area_task_open = HearingTask.objects.for_store(self.store).filter(
+                customer=customer,
+                field_name="area",
+                status=HearingTask.STATUS_OPEN,
+            ).exists()
+            if area_task_open:
+                ctx["recent_areas"] = _get_recent_areas(self.store)
+        response = render(request, "ui/staff/_zone_task.html", ctx)
         if not remaining.exists():
             response["HX-Trigger"] = "all-tasks-done"
         return response

--- a/ui/staff/views/session.py
+++ b/ui/staff/views/session.py
@@ -163,7 +163,13 @@ class CustomerFieldUpdateView(LoginRequiredMixin, StaffRequiredMixin, StoreMixin
                 "filled": False,
             }
             if field_name == "area":
-                ctx["recent_areas"] = _get_recent_areas(self.store)
+                area_task_open = HearingTask.objects.for_store(self.store).filter(
+                    customer=customer,
+                    field_name="area",
+                    status=HearingTask.STATUS_OPEN,
+                ).exists()
+                if area_task_open:
+                    ctx["recent_areas"] = _get_recent_areas(self.store)
             response = render(
                 request,
                 "ui/staff/_zone_task.html",

--- a/ui/staff/views/session.py
+++ b/ui/staff/views/session.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.db.models import Max
 from django.http import HttpResponse, QueryDict
 from django.shortcuts import get_object_or_404, render
 from django.views import View
@@ -50,6 +51,19 @@ SEGMENT_DISPLAY = {
 }
 
 
+def _get_recent_areas(store, limit=10):
+    """Store 内の Customer から最近入力された area のユニーク値を取得する。"""
+    rows = (
+        Customer.objects.for_store(store)
+        .filter(area__isnull=False)
+        .exclude(area="")
+        .values("area")
+        .annotate(last_updated=Max("updated_at"))
+        .order_by("-last_updated")[:limit]
+    )
+    return [row["area"] for row in rows]
+
+
 def _build_hearing_summary(customer):
     hearing_summary = []
     for field_name, config in TASK_FIELD_CONFIG.items():
@@ -94,6 +108,12 @@ class SessionView(LoginRequiredMixin, StaffRequiredMixin, StoreMixin, TemplateVi
         for task in open_tasks:
             task.config = TASK_FIELD_CONFIG.get(task.field_name, {})
 
+        area_task_open = any(t.field_name == "area" for t in open_tasks)
+        if area_task_open:
+            context["recent_areas"] = _get_recent_areas(self.store)
+        else:
+            context["recent_areas"] = []
+
         recent_visits = list(
             Visit.objects.for_store(self.store)
             .filter(customer=customer)
@@ -135,16 +155,19 @@ class CustomerFieldUpdateView(LoginRequiredMixin, StaffRequiredMixin, StoreMixin
             if task is None:
                 task = SimpleNamespace(field_name=field_name or "unknown")
             err_txt = form.errors.as_text()
+            ctx = {
+                "task": task,
+                "config": TASK_FIELD_CONFIG.get(field_name, {}),
+                "customer": customer,
+                "error": err_txt,
+                "filled": False,
+            }
+            if field_name == "area":
+                ctx["recent_areas"] = _get_recent_areas(self.store)
             response = render(
                 request,
                 "ui/staff/_zone_task.html",
-                {
-                    "task": task,
-                    "config": TASK_FIELD_CONFIG.get(field_name, {}),
-                    "customer": customer,
-                    "error": err_txt,
-                    "filled": False,
-                },
+                ctx,
             )
             response.status_code = 422
             return response

--- a/ui/templates/ui/staff/_zone_task.html
+++ b/ui/templates/ui/staff/_zone_task.html
@@ -43,7 +43,23 @@
         <span class="font-medium text-text-primary">{{ config.label }}</span>
         <span class="text-sm text-text-secondary shrink-0">タップして入力 ▸</span>
       </button>
-      <div x-show="open" x-transition x-cloak class="mt-3 flex flex-col gap-2" style="display: none;">
+      <div x-show="open" x-transition x-cloak class="mt-3 flex flex-col gap-3" style="display: none;">
+        {% if recent_areas %}
+          <div class="flex flex-wrap gap-2">
+            {% for area_value in recent_areas %}
+              <button
+                type="button"
+                hx-patch="/s/customers/{{ customer.id }}/field/"
+                hx-vals='{"field": "{{ task.field_name }}", "value": "{{ area_value }}"}'
+                hx-target="#zone-{{ task.field_name }}"
+                hx-swap="outerHTML"
+                class="inline-flex items-center rounded-full border border-border-default bg-bg-surface px-3 py-1.5 text-sm text-text-primary hover:border-accent active:bg-accent-light"
+              >
+                {{ area_value }}
+              </button>
+            {% endfor %}
+          </div>
+        {% endif %}
         <input
           type="text"
           x-model="val"

--- a/ui/templates/ui/staff/_zone_task.html
+++ b/ui/templates/ui/staff/_zone_task.html
@@ -50,7 +50,7 @@
               <button
                 type="button"
                 hx-patch="/s/customers/{{ customer.id }}/field/"
-                hx-vals='{"field": "{{ task.field_name }}", "value": "{{ area_value }}"}'
+                hx-vals='{"field": "{{ task.field_name }}", "value": "{{ area_value|escapejs }}"}'
                 hx-target="#zone-{{ task.field_name }}"
                 hx-swap="outerHTML"
                 class="inline-flex items-center rounded-full border border-border-default bg-bg-surface px-3 py-1.5 text-sm text-text-primary hover:border-accent active:bg-accent-light"

--- a/ui/tests/test_us02.py
+++ b/ui/tests/test_us02.py
@@ -130,3 +130,20 @@ class US02RecentAreasTests(TestCase):
         )
         self.assertEqual(response.status_code, 422)
         self.assertContains(response, "履歴エリア表示用", status_code=422)
+
+    def test_session_recent_areas_special_chars_escaped(self):
+        """area に特殊文字が含まれても hx-vals が壊れないこと"""
+        Customer.objects.create(store=self.store, name="特殊", area='渋谷"周辺')
+        c = Customer.objects.create(store=self.store, name="対象特殊", area=None)
+        HearingTask.objects.create(
+            store=self.store,
+            customer=c,
+            field_name="area",
+            status=HearingTask.STATUS_OPEN,
+        )
+        response = self.client.get(self._session_url(c))
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        # escapejs により " が \u0022 にエスケープされること
+        self.assertIn("\\u0022", content)
+        self.assertNotIn('value": "渋谷"周辺"', content)

--- a/ui/tests/test_us02.py
+++ b/ui/tests/test_us02.py
@@ -1,0 +1,132 @@
+from datetime import timedelta
+from urllib.parse import urlencode
+
+from django.test import TestCase
+from django.utils import timezone
+
+from accounts.models import Staff
+from customers.models import Customer
+from tasks.models import HearingTask
+from tenants.models import Store, StoreGroup
+
+
+class US02RecentAreasTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.store_group = StoreGroup.objects.create(name="US02 Recent Areas Group")
+        cls.store = Store.objects.create(store_group=cls.store_group, name="US02 Store")
+        cls.other_store = Store.objects.create(store_group=cls.store_group, name="US02 Other Store")
+        cls.staff = Staff.objects.create_user(
+            store=cls.store,
+            display_name="US02 Staff",
+            role="staff",
+            staff_type="regular",
+        )
+
+    def setUp(self):
+        self.client.force_login(self.staff)
+
+    def _session_url(self, customer):
+        return f"/s/customers/{customer.pk}/session/"
+
+    def test_session_recent_areas_in_context(self):
+        Customer.objects.create(store=self.store, name="履歴1", area="渋谷周辺")
+        Customer.objects.create(store=self.store, name="履歴2", area="港区")
+        Customer.objects.create(store=self.store, name="履歴3", area="渋谷周辺")
+        c = Customer.objects.create(store=self.store, name="対象", area=None)
+        HearingTask.objects.create(
+            store=self.store,
+            customer=c,
+            field_name="area",
+            status=HearingTask.STATUS_OPEN,
+        )
+        response = self.client.get(self._session_url(c))
+        self.assertEqual(response.status_code, 200)
+        areas = response.context["recent_areas"]
+        self.assertIn("渋谷周辺", areas)
+        self.assertIn("港区", areas)
+        self.assertEqual(areas.count("渋谷周辺"), 1)
+
+    def test_session_recent_areas_empty_when_no_data(self):
+        c = Customer.objects.create(store=self.store, name="エリアなし", area=None)
+        HearingTask.objects.create(
+            store=self.store,
+            customer=c,
+            field_name="area",
+            status=HearingTask.STATUS_OPEN,
+        )
+        response = self.client.get(self._session_url(c))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["recent_areas"], [])
+
+    def test_session_recent_areas_store_scope(self):
+        Customer.objects.create(store=self.other_store, name="他店", area="他店エリア")
+        Customer.objects.create(store=self.store, name="自店", area="自店エリア")
+        c = Customer.objects.create(store=self.store, name="対象2", area=None)
+        HearingTask.objects.create(
+            store=self.store,
+            customer=c,
+            field_name="area",
+            status=HearingTask.STATUS_OPEN,
+        )
+        response = self.client.get(self._session_url(c))
+        self.assertEqual(response.status_code, 200)
+        areas = response.context["recent_areas"]
+        self.assertIn("自店エリア", areas)
+        self.assertNotIn("他店エリア", areas)
+
+    def test_session_recent_areas_limit_10(self):
+        base = timezone.now()
+        for i in range(11):
+            cust = Customer.objects.create(
+                store=self.store,
+                name=f"Limit{i}",
+                area=f"エリア{i:02d}",
+            )
+            Customer.objects.filter(pk=cust.pk).update(
+                updated_at=base - timedelta(minutes=i),
+            )
+        c = Customer.objects.create(store=self.store, name="LimitTarget", area=None)
+        HearingTask.objects.create(
+            store=self.store,
+            customer=c,
+            field_name="area",
+            status=HearingTask.STATUS_OPEN,
+        )
+        response = self.client.get(self._session_url(c))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["recent_areas"]), 10)
+
+    def test_session_recent_areas_empty_when_area_task_closed(self):
+        Customer.objects.create(store=self.store, name="過去", area="渋谷周辺")
+        c = Customer.objects.create(store=self.store, name="年齢のみ", area=None)
+        HearingTask.objects.create(
+            store=self.store,
+            customer=c,
+            field_name="age",
+            status=HearingTask.STATUS_OPEN,
+        )
+        response = self.client.get(self._session_url(c))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["recent_areas"], [])
+
+    def test_field_update_error_includes_recent_areas(self):
+        Customer.objects.create(store=self.store, name="履歴顧客", area="履歴エリア表示用")
+        c = Customer.objects.create(store=self.store, name="PATCH対象", area=None)
+        HearingTask.objects.create(
+            store=self.store,
+            customer=c,
+            field_name="area",
+            status=HearingTask.STATUS_OPEN,
+        )
+        url = f"/s/customers/{c.pk}/field/"
+        long_value = "x" * 256
+        body = urlencode({"field": "area", "value": long_value})
+        response = self.client.generic(
+            "PATCH",
+            url,
+            data=body,
+            content_type="application/x-www-form-urlencoded",
+        )
+        self.assertEqual(response.status_code, 422)
+        self.assertContains(response, "履歴エリア表示用", status_code=422)

--- a/ui/tests/test_us02.py
+++ b/ui/tests/test_us02.py
@@ -131,6 +131,27 @@ class US02RecentAreasTests(TestCase):
         self.assertEqual(response.status_code, 422)
         self.assertContains(response, "履歴エリア表示用", status_code=422)
 
+    def test_field_update_empty_area_keeps_recent_areas(self):
+        """area を空文字で PATCH 成功した場合も recent_areas が返ること"""
+        Customer.objects.create(store=self.store, name="履歴あり", area="渋谷周辺")
+        c = Customer.objects.create(store=self.store, name="空入力対象", area=None)
+        HearingTask.objects.create(
+            store=self.store,
+            customer=c,
+            field_name="area",
+            status=HearingTask.STATUS_OPEN,
+        )
+        url = f"/s/customers/{c.pk}/field/"
+        body = urlencode({"field": "area", "value": ""})
+        response = self.client.generic(
+            "PATCH",
+            url,
+            data=body,
+            content_type="application/x-www-form-urlencoded",
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "渋谷周辺")
+
     def test_session_recent_areas_special_chars_escaped(self):
         """area に特殊文字が含まれても hx-vals が壊れないこと"""
         Customer.objects.create(store=self.store, name="特殊", area='渋谷"周辺')


### PR DESCRIPTION
## Summary
- 居住エリアのヒアリングタスクに、同一 Store 内の過去入力値を履歴ボタンとして表示
- ワンタップで即確定（HTMX PATCH、selection タイプと同じ UX）
- テキスト入力も引き続き利用可能
- Resolves #45

## Test plan
- [ ] 6 new tests + 506 existing tests PASS
- [ ] 履歴ボタンタップで area が即確定
- [ ] Store スコープが守られている

🤖 Generated with [Claude Code](https://claude.com/claude-code)